### PR TITLE
Add note about installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ and basic map data info (without tiles and resource location info):
 Or simply:
 
 	s2prot -map sample.rep
+	
+## Installing the `screp` CLI app
+
+Install the command line application via:
+
+	go get github.com/icza/screp/...
+
+This will place `screp` inside `$GOPATH/bin/`.
 
 ## Example projects using this
 


### PR DESCRIPTION
This is to add a note about installing `screp` for folks who aren’t familiar with go packaging, but still want to use the CLI app. Closes #9