### PR TITLE
Interpret field values for new 1.21 commands

### DIFF
--- a/rep/repcmd/cmd.go
+++ b/rep/repcmd/cmd.go
@@ -155,6 +155,14 @@ type RightClickCmd struct {
 	Queued bool
 }
 
+// UnloadCmd describes an unload command.
+type UnloadCmd struct {
+	*Base
+
+	// UnitTag is the unloaded unit's tag if it's valid.
+	UnitTag UnitTag
+}
+
 // TargetedOrderCmd describes a targeted order command. Type: TypeTargetedOrder
 type TargetedOrderCmd struct {
 	*Base

--- a/rep/repcmd/types.go
+++ b/rep/repcmd/types.go
@@ -77,7 +77,12 @@ const (
 	TypeIDMergeDarkArchon    byte = 0x5a
 	TypeIDMakeGamePublic     byte = 0x5b
 	TypeIDChat               byte = 0x5c
+	TypeIDRightClick121      byte = 0x60
+	TypeIDTargetedOrder121   byte = 0x61
+	TypeIDUnload121          byte = 0x62
 	TypeIDSelect121          byte = 0x63
+	TypeIDSelectAdd121       byte = 0x64
+	TypeIDSelectRemove121    byte = 0x65
 )
 
 // Type describes the command type.
@@ -161,7 +166,12 @@ var Types = []*Type{
 	{e("Merge Dark Archon"), TypeIDMergeDarkArchon},
 	{e("Make Game Public"), TypeIDMakeGamePublic},
 	{e("Chat"), TypeIDChat},
-	{e("Select121"), TypeIDSelect121},
+	{e("Right Click 121"), TypeIDRightClick121},
+	{e("Targeted Order 121"), TypeIDTargetedOrder121},
+	{e("Unload 121"), TypeIDUnload121},
+	{e("Select 121"), TypeIDSelect121},
+	{e("Select Add 121"), TypeIDSelectAdd121},
+	{e("Select Remove 121"), TypeIDSelectRemove121},
 }
 
 // Named command types
@@ -237,7 +247,12 @@ var (
 	TypeMergeDarkArchon    = Types[68]
 	TypeMakeGamePublic     = Types[69]
 	TypeChat               = Types[70]
-	TypeSelect121          = Types[71]
+	TypeRightClick121      = Types[71]
+	TypeTargetedOrder121   = Types[72]
+	TypeUnload121          = Types[73]
+	TypeSelect121          = Types[74]
+	TypeSelectAdd121       = Types[75]
+	TypeSelectRemove121    = Types[76]
 )
 
 // typeIDType maps from type ID to type.

--- a/rep/repcmd/units.go
+++ b/rep/repcmd/units.go
@@ -240,6 +240,7 @@ var Units = []*Unit{
 	{e("Zerg Vespene Gas Sac Type 2"), 0xE1},
 	{e("Terran Vespene Gas Tank Type 1"), 0xE2},
 	{e("Terran Vespene Gas Tank Type 2"), 0xE3},
+	{e("None"), 0xE4},
 }
 
 // unitIDUnit maps from unit ID to unit.

--- a/repparser/repparser.go
+++ b/repparser/repparser.go
@@ -415,9 +415,9 @@ func parseCommands(data []byte, r *rep.Replay) error {
 				}
 
 			case repcmd.TypeIDUnload:
-				cmd = &repcmd.GeneralCmd{
-					Base: base,
-					Data: sr.readSlice(2),
+				cmd = &repcmd.UnloadCmd{
+					Base:    base,
+					UnitTag: repcmd.UnitTag(sr.getUint16()),
 				}
 
 			case repcmd.TypeIDLiftOff:


### PR DESCRIPTION
This patch adds support for extracting more info from new commands introduced in the 1.21 patch.

Their structure should be identical to corresponding commands from previous versions, sans a few unknown - always zero (?) fields.

It also adds the [None](https://staredit-network.fandom.com/wiki/Units.dat_Entry_Listing) type unit (0xe4), which is used in TargetedOrders.

I tested this patch using a set of replays from 1.23 (attached). Please let me know if there is a better way how I could check that they are correct.

[test-replays.tar.gz](https://github.com/icza/screp/files/3665640/test-replays.tar.gz)

